### PR TITLE
Correct path to MultiCopy auxilliary files

### DIFF
--- a/Conversion/MultiCopy.FCMacro
+++ b/Conversion/MultiCopy.FCMacro
@@ -92,7 +92,7 @@ __Help__='Select one or more FreeCAD objects, then click on the MultiCopy button
 __Status__='stable'
 __Requires__='Freecad >= v0.17'
 __Communication__='https://github.com/melwyncarlo/MultiCopy/issues'
-__Files__='MultiCopyGui.py, MultiCopyCore.py, MultiCopyAuxFunc.py, MultiCopy/resources/MultiCopy_Main_Dialog.ui, MultiCopy/resources/MultiCopy_Commands_Dialog.ui, MultiCopy/resources/MultiCopy.svg'
+__Files__='MultiCopy/MultiCopyGui.py, MultiCopy/MultiCopyCore.py, MultiCopy/MultiCopyAuxFunc.py, MultiCopy/resources/MultiCopy_Main_Dialog.ui, MultiCopy/resources/MultiCopy_Commands_Dialog.ui, MultiCopy/resources/MultiCopy.svg'
 
 
 


### PR DESCRIPTION
- [X] Please check this box if you're not submitting a new macro.

The Addon Manager can't find the aux files from this macro because they ignore the subdirectory they are in.